### PR TITLE
feat(subject/ISSUE-013): agregar creacion de materias personalizadas

### DIFF
--- a/src/main/java/org/manageSchool/subject/SubjectController.java
+++ b/src/main/java/org/manageSchool/subject/SubjectController.java
@@ -1,0 +1,23 @@
+package org.manageSchool.subject;
+
+import java.util.Scanner;
+
+public class SubjectController {
+    private final SubjectService service = new SubjectService();  // Instancia del servicio para acceder a la logica
+
+    // ============ ISSUE-013: Solo crear materia ============
+    public void mostrarMenuCrear(Scanner scanner) {  // Metodo que muestra el formulario para crear materia
+        System.out.println("\n--- CREAR NUEVA MATERIA ---");  // Titulo de la seccion
+        System.out.print("Nombre de la materia: ");  // Solicita el nombre al usuario
+        String nombre = scanner.nextLine().trim();  // Lee el nombre y elimina espacios al inicio y final
+
+        try {  // Intenta ejecutar la creacion
+            Subject nueva = service.create(nombre);  // Llama al servicio para crear la materia
+            System.out.println("Materia creada exitosamente!");  // Mensaje de exito
+            System.out.println("   ID: " + nueva.getId());  // Muestra el ID generado
+            System.out.println("   Nombre: " + nueva.getNombre());  // Muestra el nombre de la materia creada
+        } catch (Exception e) {  // Captura cualquier error
+            System.out.println("Error: " + e.getMessage());  // Muestra el mensaje de error
+        }
+    }
+}

--- a/src/main/java/org/manageSchool/subject/SubjectService.java
+++ b/src/main/java/org/manageSchool/subject/SubjectService.java
@@ -30,4 +30,22 @@ public class SubjectService {  // Clase que contiene la lógica de negocio para 
             }
         }
     }
+
+    // ============ ISSUE-013: Crear materia personalizada ============
+    public Subject create(String nombre) {  // Metodo para crear una nueva materia personalizada
+        if (nombre == null || nombre.trim().isEmpty()) {  // Valida que el nombre no sea nulo ni vacio
+            throw new RuntimeException("El nombre de la materia no puede estar vacio.");  // Lanza error si esta vacio
+        }
+        if (repo.existsByNombre(nombre)) {  // Verifica si ya existe una materia con ese nombre
+            throw new RuntimeException("Ya existe una materia con ese nombre.");  // Lanza error si ya existe
+        }
+        Subject subject = new Subject(  // Crea un nuevo objeto Subject
+                UUID.randomUUID().toString(),  // Genera un ID unico universal
+                nombre,  // Asigna el nombre ingresado por el usuario
+                false,  // predeterminada = false (es una materia creada por el Admin)
+                true  // activa = true (esta habilitada para usar)
+        );
+        repo.save(subject);  // Guarda la materia en el archivo subjects.json
+        return subject;  // Devuelve la materia creada
+    }
 }

--- a/src/test/java/test/SubjectServiceTest.java
+++ b/src/test/java/test/SubjectServiceTest.java
@@ -1,57 +1,85 @@
-package test;
-
-import org.junit.jupiter.api.BeforeEach;  // Se ejecuta antes de cada prueba
-import org.junit.jupiter.api.Test;  // Marca un metodo como prueba unitaria
-import org.manageSchool.subject.Subject;  // Importa el modelo Subject
+package test;  // Define el paquete donde esta esta clase de prueba
+import java.util.ArrayList;
+import org.junit.jupiter.api.BeforeEach;  // Importa la anotacion que se ejecuta antes de cada prueba
+import org.junit.jupiter.api.Test;  // Importa la anotacion que marca un metodo como prueba
+import org.manageSchool.subject.Subject;  // Importa el modelo Subject para usarlo en las pruebas
 import org.manageSchool.subject.SubjectRepository;  // Importa el repositorio para verificar datos
 import org.manageSchool.subject.SubjectService;  // Importa el servicio que vamos a probar
-
-import static org.junit.jupiter.api.Assertions.*;  // Importa las verificaciones (assertEquals, assertTrue, etc.)
+import org.manageSchool.shared.util.JsonFileManager;
+import static org.junit.jupiter.api.Assertions.*;  // Importa todos los metodos de verificacion
 
 class SubjectServiceTest {  // Clase que contiene todas las pruebas de SubjectService
     private SubjectService subjectService;  // Declara el servicio que vamos a probar
+    private SubjectRepository repo;  // Declara el repositorio para verificar datos en JSON
 
-    @BeforeEach  // Esto se ejecuta ANTES de cada prueba (se repite para cada @Test)
-    void setUp() {  // Metodo de configuración inicial
-        subjectService = new SubjectService();  // Crea una instancia nueva del servicio para cada prueba
+    @BeforeEach  // Esta anotacion hace que el metodo se ejecute ANTES de cada prueba
+    void setUp() {  // Metodo de configuracion inicial
+        subjectService = new SubjectService();  // Crea una instancia nueva del servicio
+        repo = new SubjectRepository();  // Crea una instancia nueva del repositorio
+
+        // Limpiar todos los datos existentes antes de cada prueba
+        JsonFileManager.writeAll("subjects.json", new ArrayList<Subject>());
+
+        // Cargar materias predeterminadas desde cero
+        subjectService.seedDefaultSubjects();  // Crea las 5 materias base del sistema
     }
 
-    @Test  // Prueba 1: Verifica que se crean exactamente 5 materias
-    void seedDefaultSubjects_creaLas5MateriasPredeterminadas() {  // Nombre descriptivo del test
-        subjectService.seedDefaultSubjects();  // Ejecuta el metodo que queremos probar
+    // ============ TESTS PARA ISSUE-012 ============
 
-        SubjectRepository repo = new SubjectRepository();  // Crea repositorio para leer el archivo
+    @Test  // Marca este metodo como una prueba unitaria
+    void seedDefaultSubjects_creaLas5MateriasPredeterminadas() {  // Prueba que se crean exactamente 5 materias
         assertEquals(5, repo.findAll().size(), "Deben crearse exactamente 5 materias");  // Verifica que hay 5 materias
     }
 
-    @Test  // Prueba 2: Verifica que al ejecutarse dos veces no se duplican
-    void seedDefaultSubjects_noDuplicaMaterias() {  // Nombre descriptivo del test
-        subjectService.seedDefaultSubjects();  // Primera ejecución: crea las 5 materias
-        subjectService.seedDefaultSubjects();  // Segunda ejecución: no debería crear duplicados
-
-        SubjectRepository repo = new SubjectRepository();  // Crea repositorio para leer el archivo
-        assertEquals(5, repo.findAll().size(), "No debe duplicar materias al ejecutarse dos veces");  // Sigue habiendo 5
+    @Test  // Marca este metodo como una prueba unitaria
+    void seedDefaultSubjects_noDuplicaMaterias() {  // Prueba que al ejecutarse dos veces no se duplican
+        subjectService.seedDefaultSubjects();  // Ejecuta seed por segunda vez
+        assertEquals(5, repo.findAll().size(), "No debe duplicar materias al ejecutarse dos veces");  // Verifica que siguen siendo 5
     }
 
-    @Test  // Prueba 3: Verifica que las materias creadas son las correctas
-    void seedDefaultSubjects_materiasCorrectas() {  // Nombre descriptivo del test
-        subjectService.seedDefaultSubjects();  // Ejecuta el metodo que queremos probar
-
-        SubjectRepository repo = new SubjectRepository();  // Crea repositorio para leer el archivo
-        assertTrue(repo.existsByNombre("Matemáticas"));  // Verifica que existe Matemáticas
-        assertTrue(repo.existsByNombre("Español"));  // Verifica que existe Español
+    @Test  // Marca este metodo como una prueba unitaria
+    void seedDefaultSubjects_materiasCorrectas() {  // Prueba que las materias creadas son las correctas
+        assertTrue(repo.existsByNombre("Matemáticas"));  // Verifica que existe Matematicas
+        assertTrue(repo.existsByNombre("Español"));  // Verifica que existe Espanol
         assertTrue(repo.existsByNombre("Ciencias Naturales"));  // Verifica que existe Ciencias Naturales
         assertTrue(repo.existsByNombre("Ciencias Sociales"));  // Verifica que existe Ciencias Sociales
-        assertTrue(repo.existsByNombre("Inglés"));  // Verifica que existe Inglés
+        assertTrue(repo.existsByNombre("Inglés"));  // Verifica que existe Ingles
     }
 
-    @Test  // Prueba 4: Verifica que todas las materias tienen predeterminada = true
-    void seedDefaultSubjects_materiasSonPredeterminadas() {  // Nombre descriptivo del test
-        subjectService.seedDefaultSubjects();  // Ejecuta el metodo que queremos probar
-
-        SubjectRepository repo = new SubjectRepository();  // Crea repositorio para leer el archivo
+    @Test  // Marca este metodo como una prueba unitaria
+    void seedDefaultSubjects_materiasSonPredeterminadas() {  // Prueba que todas tienen predeterminada = true
         for (Subject s : repo.findAll()) {  // Recorre cada materia creada
             assertTrue(s.isPredeterminada(), s.getNombre() + " debe ser predeterminada");  // Verifica que sea predeterminada
         }
+    }
+
+    // ============ TESTS PARA ISSUE-013 ============
+
+    @Test  // Marca este metodo como una prueba unitaria
+    void create_creaMateriaPersonalizadaExitosamente() {  // Prueba crear materia personalizada con exito
+        Subject nueva = subjectService.create("Arte");  // Llama al metodo create para crear "Arte"
+
+        assertNotNull(nueva.getId());  // Verifica que el ID no sea nulo
+        assertEquals("Arte", nueva.getNombre());  // Verifica que el nombre sea "Arte"
+        assertFalse(nueva.isPredeterminada());  // Verifica que NO sea predeterminada
+        assertTrue(nueva.isActiva());  // Verifica que este activa
+        assertTrue(repo.existsByNombre("Arte"));  // Verifica que existe en el repositorio
+    }
+
+    @Test  // Marca este metodo como una prueba unitaria
+    void create_lanzaErrorSiNombreVacio() {  // Prueba que no permite crear materia con nombre vacio
+        Exception exception = assertThrows(RuntimeException.class, () -> {  // Espera que lance una excepcion
+            subjectService.create("");  // Intenta crear con nombre vacio
+        });
+        assertEquals("El nombre de la materia no puede estar vacio.", exception.getMessage());  // Verifica el mensaje de error
+    }
+
+    @Test  // Marca este metodo como una prueba unitaria
+    void create_lanzaErrorSiNombreDuplicado() {  // Prueba que no permite crear materia con nombre duplicado
+        subjectService.create("Musica");  // Crea una materia llamada "Musica" primero
+        Exception exception = assertThrows(RuntimeException.class, () -> {  // Espera que lance una excepcion
+            subjectService.create("Musica");  // Intenta crear otra materia con el mismo nombre
+        });
+        assertEquals("Ya existe una materia con ese nombre.", exception.getMessage());  // Verifica el mensaje de error
     }
 }


### PR DESCRIPTION
## ISSUE-013: Crear materia personalizada (Admin)

### ¿Que se hizo?
- Agregar metodo `create()` en `SubjectService` para crear materias personalizadas
- Crear `SubjectController` con metodo `mostrarMenuCrear()` para la interaccion por consola
- Agregar tests unitarios para `create()` en `SubjectServiceTest`

### Validaciones incluidas:
- El nombre no puede estar vacio
- No puede haber dos materias con el mismo nombre
- Las materias personalizadas tienen `predeterminada = false`

### Tests agregados (3 nuevos):
- `create_creaMateriaPersonalizadaExitosamente()` - Verifica creacion correcta
- `create_lanzaErrorSiNombreVacio()` - Verifica rechazo de nombre vacio
- `create_lanzaErrorSiNombreDuplicado()` - Verifica rechazo de duplicados

### Tests totales: 7/7 pasando

### Archivos modificados/creados:
- `src/main/java/org/manageSchool/subject/SubjectService.java` (agregado metodo create)
- `src/main/java/org/manageSchool/subject/SubjectController.java` (nuevo archivo)
- `test/java/test/SubjectServiceTest.java` (agregados tests de create)

### Dependencias:
- No requiere cambios en `Main.java` (el menu principal se integrara en otra issue)
- Depende de ISSUE-012 (materias predeterminadas ya existentes)

### Nota:
El metodo `create()` usa las validaciones definidas en el SRS y los casos de prueba CP-SUB-002.