### PR TITLE
feat(task): add TaskController for task management UI (#16)

### DIFF
--- a/src/main/java/org/manageSchool/task/TaskController.java
+++ b/src/main/java/org/manageSchool/task/TaskController.java
@@ -1,0 +1,243 @@
+package org.manageSchool.task;
+
+import org.manageSchool.shared.AppException;
+import org.manageSchool.subject.SubjectService;
+import org.manageSchool.subject.Subject;
+import org.manageSchool.task.Task;
+import org.manageSchool.task.TaskService;
+
+import java.util.List;
+import java.util.Scanner;
+
+
+public class TaskController {
+
+    private final TaskService    service        = new TaskService();
+    private final SubjectService subjectService = new SubjectService();
+
+
+    public void mostrarMenu(Scanner scanner, String profesorId) {
+        boolean volver = false;
+
+        while (!volver) {
+            imprimirMenuTareas();
+            int opcion = leerOpcion(scanner);
+
+            switch (opcion) {
+                case 1 -> flujoCrear(scanner, profesorId);
+                case 2 -> flujoListar(scanner, profesorId);
+                case 3 -> flujoEditar(scanner, profesorId);
+                case 4 -> flujoEliminar(scanner, profesorId);
+                case 5 -> volver = true;
+                default -> System.out.println("  ⚠ Opción inválida. Ingrese un número del 1 al 5.");
+            }
+        }
+    }
+
+
+
+    private void flujoCrear(Scanner scanner, String profesorId) {
+        System.out.println("\n--- CREAR NUEVA TAREA ---");
+
+        List<Subject> materias = subjectService.listAll();
+        if (materias.isEmpty()) {
+            System.out.println("  ⚠ No hay materias disponibles en el sistema.");
+            return;
+        }
+
+        imprimirMaterias(materias);
+        System.out.print("  Seleccione el número de la materia: ");
+        int seleccion = leerOpcion(scanner);
+
+        if (seleccion < 1 || seleccion > materias.size()) {
+            System.out.println("  ⚠ Selección inválida.");
+            return;
+        }
+
+        Subject materiaElegida = materias.get(seleccion - 1);
+        System.out.println("  Materia seleccionada: " + materiaElegida.getNombre());
+
+        System.out.print("  Título de la tarea *: ");
+        String titulo = scanner.nextLine().trim();
+
+        System.out.print("  Descripción (Enter para omitir): ");
+        String descripcion = scanner.nextLine().trim();
+        if (descripcion.isEmpty()) descripcion = null;
+
+        System.out.print("  Fecha límite yyyy-MM-dd (Enter para omitir): ");
+        String fechaLimite = scanner.nextLine().trim();
+        if (fechaLimite.isEmpty()) fechaLimite = null;
+
+        try {
+            Task creada = service.create(
+                    titulo, descripcion, fechaLimite,
+                    materiaElegida.getId(),   // ID real desde subjects.json
+                    profesorId
+            );
+            System.out.println("\n  ✅ Tarea creada exitosamente.");
+            imprimirDetalleTarea(creada, materiaElegida.getNombre());
+        } catch (AppException e) {
+            System.out.println("  ❌ " + e.getMessage());
+        }
+    }
+
+    private void flujoListar(Scanner scanner, String profesorId) {
+        System.out.println("\n--- VER TAREAS POR MATERIA ---");
+
+        List<Subject> materias = subjectService.listAll();
+        if (materias.isEmpty()) {
+            System.out.println("  ⚠ No hay materias disponibles.");
+            return;
+        }
+
+        imprimirMaterias(materias);
+        System.out.print("  Seleccione el número de la materia: ");
+        int seleccion = leerOpcion(scanner);
+
+        if (seleccion < 1 || seleccion > materias.size()) {
+            System.out.println("  ⚠ Selección inválida.");
+            return;
+        }
+
+        Subject materiaElegida = materias.get(seleccion - 1);
+        List<Task> tareas = service.listBySubject(materiaElegida.getId(), profesorId);
+
+        System.out.println("\n  Tareas de: " + materiaElegida.getNombre());
+        imprimirSeparador();
+
+        if (tareas.isEmpty()) {
+            System.out.println("  (No tienes tareas en esta materia)");
+        } else {
+            imprimirCabeceraTareas();
+            tareas.forEach(this::imprimirFilaTarea);
+        }
+
+        imprimirSeparador();
+    }
+
+    private void flujoEditar(Scanner scanner, String profesorId) {
+        System.out.println("\n--- EDITAR TAREA ---");
+        System.out.println("  (Usa 'Ver tareas por materia' para consultar los IDs)");
+        System.out.print("  ID de la tarea a editar: ");
+        String taskId = scanner.nextLine().trim();
+
+        if (taskId.isEmpty()) {
+            System.out.println("  ⚠ Operación cancelada.");
+            return;
+        }
+
+        System.out.print("  Nuevo título *: ");
+        String titulo = scanner.nextLine().trim();
+
+        System.out.print("  Nueva descripción (Enter para dejar en blanco): ");
+        String descripcion = scanner.nextLine().trim();
+        if (descripcion.isEmpty()) descripcion = null;
+
+        System.out.print("  Nueva fecha límite yyyy-MM-dd (Enter para dejar en blanco): ");
+        String fechaLimite = scanner.nextLine().trim();
+        if (fechaLimite.isEmpty()) fechaLimite = null;
+
+        try {
+            service.update(taskId, titulo, descripcion, fechaLimite, profesorId);
+            // Mensaje exacto del CP-TASK-003
+            System.out.println("\n  ✅ Tarea actualizada correctamente.");
+        } catch (AppException e) {
+            System.out.println("  ❌ " + e.getMessage());
+        }
+    }
+
+    private void flujoEliminar(Scanner scanner, String profesorId) {
+        System.out.println("\n--- ELIMINAR TAREA ---");
+        System.out.println("  (Usa 'Ver tareas por materia' para consultar los IDs)");
+        System.out.print("  ID de la tarea a eliminar: ");
+        String taskId = scanner.nextLine().trim();
+
+        if (taskId.isEmpty()) {
+            System.out.println("  ⚠ Operación cancelada.");
+            return;
+        }
+
+        int cantidadNotas = service.countGradesByTask(taskId);
+
+        if (cantidadNotas > 0) {
+            System.out.printf(
+                    "%n  ⚠ Esta tarea tiene %d nota(s). Se eliminarán también. ¿Continuar? (s/n): ",
+                    cantidadNotas
+            );
+        } else {
+            System.out.print("  ¿Confirmar eliminación? (s/n): ");
+        }
+
+        String respuesta = scanner.nextLine().trim().toLowerCase();
+        boolean confirmar = respuesta.equals("s") || respuesta.equals("si") || respuesta.equals("sí");
+
+        if (!confirmar) {
+            System.out.println("  Operación cancelada.");
+            return;
+        }
+
+        try {
+            service.delete(taskId, profesorId);
+            System.out.println("  ✅ Tarea eliminada correctamente.");
+        } catch (AppException e) {
+            System.out.println("  ❌ " + e.getMessage());
+        }
+    }
+
+    private void imprimirMenuTareas() {
+        System.out.println("\n╔══════════════════════════════╗");
+        System.out.println("║     GESTIÓN DE TAREAS        ║");
+        System.out.println("╠══════════════════════════════╣");
+        System.out.println("║  1. Crear tarea              ║");
+        System.out.println("║  2. Ver tareas por materia   ║");
+        System.out.println("║  3. Editar tarea             ║");
+        System.out.println("║  4. Eliminar tarea           ║");
+        System.out.println("║  5. Volver                   ║");
+        System.out.println("╚══════════════════════════════╝");
+        System.out.print("  Opción: ");
+    }
+    
+    private void imprimirMaterias(List<Subject> materias) {
+        System.out.println();
+        for (int i = 0; i < materias.size(); i++) {
+            String tipo = materias.get(i).isPredeterminada() ? " (predeterminada)" : "";
+            System.out.printf("  %d. %s%s%n", i + 1, materias.get(i).getNombre(), tipo);
+        }
+        System.out.println();
+    }
+
+    private void imprimirCabeceraTareas() {
+        System.out.printf("  %-36s %-30s %-12s%n", "ID", "TÍTULO", "FECHA LÍMITE");
+        System.out.println("  " + "-".repeat(80));
+    }
+
+    private void imprimirFilaTarea(Task t) {
+        String fecha  = t.getFechaLimite() != null ? t.getFechaLimite() : "(sin fecha)";
+        String titulo = t.getTitulo().length() > 28
+                ? t.getTitulo().substring(0, 25) + "..."
+                : t.getTitulo();
+        System.out.printf("  %-36s %-30s %-12s%n", t.getId(), titulo, fecha);
+    }
+
+    private void imprimirDetalleTarea(Task t, String materiaNombre) {
+        System.out.println("  ─────────────────────────────────────");
+        System.out.println("  ID          : " + t.getId());
+        System.out.println("  Título      : " + t.getTitulo());
+        System.out.println("  Materia     : " + materiaNombre);
+        System.out.println("  Descripción : " + (t.getDescripcion() != null ? t.getDescripcion() : "(sin descripción)"));
+        System.out.println("  Fecha límite: " + (t.getFechaLimite() != null ? t.getFechaLimite() : "(sin fecha)"));
+        System.out.println("  ─────────────────────────────────────");
+    }
+
+    private void imprimirSeparador() {
+        System.out.println("  " + "─".repeat(80));
+    }
+
+    private int leerOpcion(Scanner scanner) {
+        try {
+            return Integer.parseInt(scanner.nextLine().trim());
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+}

--- a/src/main/java/org/manageSchool/task/TaskRepository.java
+++ b/src/main/java/org/manageSchool/task/TaskRepository.java
@@ -50,9 +50,6 @@ public class TaskRepository {
                 .findFirst();
     }
 
-    // -------------------------------------------------------------------------
-    // ESCRITURA
-    // -------------------------------------------------------------------------
 
     /**
      * @param task Tarea a guardar (debe tener ID, titulo, materiaId y profesorId)

--- a/src/test/java/test/TaskServiceTest.java
+++ b/src/test/java/test/TaskServiceTest.java
@@ -1,58 +1,367 @@
 package test;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.DisplayName;
+
 import org.manageSchool.shared.AppException;
+import org.manageSchool.shared.util.JsonFileManager;
 import org.manageSchool.task.Task;
 import org.manageSchool.task.TaskService;
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@TestMethodOrder(MethodOrderer.DisplayName.class)
 class TaskServiceTest {
 
-    private TaskService taskService;
+    private static final String PROF_ID      = "prof-001";
+    private static final String OTRO_PROF_ID = "prof-999";
+    private static final String MATERIA_ESP  = "mat-espanol";
+    private static final String MATERIA_MAT  = "mat-matematicas";
+
+    private Path       tempDir;
+    private String     originalUserDir;
+    private TaskService service;
 
     @BeforeEach
-    void setUp() {
-        taskService = new TaskService();
-        // Nota: Como tu Repo escribe en "tasks.json", ten cuidado de que
-        // este archivo exista o usa un entorno de pruebas.
+    void setUp() throws IOException {
+        originalUserDir = System.getProperty("user.dir");
+        tempDir = Files.createTempDirectory("schoolapp-task-test-");
+        System.setProperty("user.dir", tempDir.toString());
+        Files.createDirectories(tempDir.resolve("data"));
+        service = new TaskService();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        System.setProperty("user.dir", originalUserDir);
+        deleteRecursively(tempDir.toFile());
     }
 
     @Test
-    @DisplayName("CP-TASK-001: Escenario de creación exitosa")
-    void debeCrearTareaCuandoLosDatosSonValidos() {
-        // Arrange (Preparar datos basados en tu HU)
-        String titulo = "Taller de álgebra";
-        String descripcion = "Capítulo 5";
-        String fechaLimite = "2025-03-01";
-        String materiaId = "MAT-101"; // ID de Matemáticas
-        String profesorId = "PROF-001";
+    @DisplayName("CP-TASK-001 | S1 | Crea tarea con todos los campos")
+    void create_allFields_success() {
+        Task result = service.create("Taller de álgebra", "Cap 5", "2025-03-01", MATERIA_MAT, PROF_ID);
 
-        // Act (Ejecutar la lógica de tu Service)
-        Task resultado = taskService.create(titulo, descripcion, fechaLimite, materiaId, profesorId);
-
-        // Assert (Verificar resultados)
-        assertNotNull(resultado.getId(), "El ID debería haberse generado con UUID");
-        assertEquals(titulo, resultado.getTitulo());
-        assertEquals(materiaId, resultado.getMateriaId());
-        System.out.println("Test Exitoso: Tarea creada -> " + resultado);
+        assertNotNull(result);
+        assertFalse(result.getId().isBlank());
+        assertEquals("Taller de álgebra", result.getTitulo());
+        assertEquals("Cap 5",             result.getDescripcion());
+        assertEquals("2025-03-01",        result.getFechaLimite());
+        assertEquals(MATERIA_MAT,         result.getMateriaId());
+        assertEquals(PROF_ID,             result.getProfesorId());
     }
 
     @Test
-    @DisplayName("CP-TASK-001: Escenario fallido sin título")
-    void debeLanzarExcepcionCuandoTituloEstaVacio() {
-        // Arrange
-        String tituloInvalido = ""; // Vacío
-        String profesorId = "PROF-001";
+    @DisplayName("CP-TASK-001 | S1 | La tarea persiste en tasks.json")
+    void create_persistsInJson() {
+        service.create("Taller de álgebra", "Cap 5", "2025-03-01", MATERIA_MAT, PROF_ID);
 
-        // Act & Assert
-        AppException exception = assertThrows(AppException.class, () -> {
-            taskService.create(tituloInvalido, "Desc", "2025-03-01", "MAT1", profesorId);
-        });
+        List<Task> fromFile = JsonFileManager.readAll("tasks.json", Task.class);
+        assertEquals(1, fromFile.size());
+        assertEquals("Taller de álgebra", fromFile.get(0).getTitulo());
+    }
 
-        // Verificamos que el mensaje sea el que definiste en tu Service
-        assertEquals("El título es obligatorio.", exception.getMessage());
+    @Test
+    @DisplayName("CP-TASK-001 | S1 | Descripción null aceptada (campo opcional)")
+    void create_nullDescription_accepted() {
+        Task result = service.create("Quiz", null, "2025-03-01", MATERIA_MAT, PROF_ID);
+        assertNull(result.getDescripcion());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-001 | S1 | Fecha null aceptada (campo opcional)")
+    void create_nullFecha_accepted() {
+        Task result = service.create("Quiz", "Desc", null, MATERIA_MAT, PROF_ID);
+        assertNull(result.getFechaLimite());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-001 | S1 | Cada tarea recibe UUID único")
+    void create_uniqueUUIDs() {
+        Task t1 = service.create("Tarea 1", null, null, MATERIA_MAT, PROF_ID);
+        Task t2 = service.create("Tarea 2", null, null, MATERIA_MAT, PROF_ID);
+        assertNotEquals(t1.getId(), t2.getId());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-001 | S1 | Título se trimea")
+    void create_trimsTitulo() {
+        Task result = service.create("  Taller de álgebra  ", null, null, MATERIA_MAT, PROF_ID);
+        assertEquals("Taller de álgebra", result.getTitulo());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-001 | S2 | Lanza AppException si título es null")
+    void create_throwsOnNullTitulo() {
+        AppException ex = assertThrows(AppException.class, () ->
+                service.create(null, "Desc", "2025-03-01", MATERIA_MAT, PROF_ID));
+        assertEquals("El título es obligatorio.", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-001 | S2 | Lanza AppException si título está vacío")
+    void create_throwsOnEmptyTitulo() {
+        AppException ex = assertThrows(AppException.class, () ->
+                service.create("", "Desc", "2025-03-01", MATERIA_MAT, PROF_ID));
+        assertEquals("El título es obligatorio.", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-001 | S2 | Lanza AppException si título es solo espacios")
+    void create_throwsOnBlankTitulo() {
+        AppException ex = assertThrows(AppException.class, () ->
+                service.create("   ", "Desc", "2025-03-01", MATERIA_MAT, PROF_ID));
+        assertEquals("El título es obligatorio.", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-001 | Lanza AppException si materiaId es null")
+    void create_throwsOnNullMateriaId() {
+        AppException ex = assertThrows(AppException.class, () ->
+                service.create("Taller", "Desc", null, null, PROF_ID));
+        assertEquals("Debe seleccionar una materia.", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-001 | Lanza AppException si fecha tiene formato inválido")
+    void create_throwsOnInvalidDate() {
+        AppException ex = assertThrows(AppException.class, () ->
+                service.create("Taller", "Desc", "01-03-2025", MATERIA_MAT, PROF_ID));
+        assertTrue(ex.getMessage().contains("Formato de fecha inválido"));
+    }
+
+    @Test
+    @DisplayName("CP-TASK-001 | No persiste si la validación falla")
+    void create_doesNotPersistOnValidationFailure() {
+        assertThrows(AppException.class, () ->
+                service.create(null, "Desc", null, MATERIA_MAT, PROF_ID));
+        assertTrue(JsonFileManager.readAll("tasks.json", Task.class).isEmpty());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-002 | Lista 3 tareas de la materia Español")
+    void listBySubject_returnsThreeTasks() {
+        service.create("Dictado 1",    null, "2025-02-01", MATERIA_ESP, PROF_ID);
+        service.create("Lectura comp", null, "2025-02-15", MATERIA_ESP, PROF_ID);
+        service.create("Redacción",    null, "2025-03-01", MATERIA_ESP, PROF_ID);
+
+        List<Task> result = service.listBySubject(MATERIA_ESP, PROF_ID);
+
+        assertEquals(3, result.size());
+        assertTrue(result.stream().anyMatch(t -> t.getTitulo().equals("Dictado 1")));
+        assertTrue(result.stream().anyMatch(t -> t.getTitulo().equals("Lectura comp")));
+        assertTrue(result.stream().anyMatch(t -> t.getTitulo().equals("Redacción")));
+    }
+
+    @Test
+    @DisplayName("CP-TASK-002 | Solo lista tareas del profesor autenticado (RNF-06)")
+    void listBySubject_isolatesByProfessor() {
+        service.create("Tarea prof 1a", null, null, MATERIA_ESP, PROF_ID);
+        service.create("Tarea prof 1b", null, null, MATERIA_ESP, PROF_ID);
+        service.create("Tarea prof 2",  null, null, MATERIA_ESP, OTRO_PROF_ID);
+
+        List<Task> result = service.listBySubject(MATERIA_ESP, PROF_ID);
+
+        assertEquals(2, result.size());
+        assertTrue(result.stream().allMatch(t -> PROF_ID.equals(t.getProfesorId())));
+    }
+
+    @Test
+    @DisplayName("CP-TASK-002 | Devuelve lista vacía si no hay tareas en esa materia")
+    void listBySubject_returnsEmptyWhenNone() {
+        List<Task> result = service.listBySubject(MATERIA_ESP, PROF_ID);
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-002 | No mezcla tareas de distintas materias")
+    void listBySubject_doesNotMixSubjects() {
+        service.create("Tarea Español",     null, null, MATERIA_ESP, PROF_ID);
+        service.create("Tarea Matemáticas", null, null, MATERIA_MAT, PROF_ID);
+
+        List<Task> result = service.listBySubject(MATERIA_ESP, PROF_ID);
+
+        assertEquals(1, result.size());
+        assertEquals("Tarea Español", result.get(0).getTitulo());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-003 | Edita la fecha límite de 2025-03-01 a 2025-03-10")
+    void update_changesFechaLimite() {
+        Task original = service.create("Taller de álgebra", "Cap 5", "2025-03-01", MATERIA_MAT, PROF_ID);
+
+        Task actualizada = service.update(original.getId(), "Taller de álgebra", "Cap 5", "2025-03-10", PROF_ID);
+
+        assertEquals("2025-03-10", actualizada.getFechaLimite());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-003 | El cambio persiste en tasks.json")
+    void update_persistsInJson() {
+        Task original = service.create("Taller de álgebra", "Cap 5", "2025-03-01", MATERIA_MAT, PROF_ID);
+        service.update(original.getId(), "Taller de álgebra", "Cap 5", "2025-03-10", PROF_ID);
+
+        List<Task> fromFile = JsonFileManager.readAll("tasks.json", Task.class);
+        assertEquals("2025-03-10", fromFile.get(0).getFechaLimite());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-003 | Edita el título correctamente")
+    void update_changesTitulo() {
+        Task original = service.create("Título viejo", null, null, MATERIA_MAT, PROF_ID);
+        Task actualizada = service.update(original.getId(), "Título nuevo", null, null, PROF_ID);
+        assertEquals("Título nuevo", actualizada.getTitulo());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-003 | Lanza AppException si la tarea no existe")
+    void update_throwsOnNonExistentTask() {
+        AppException ex = assertThrows(AppException.class, () ->
+                service.update("id-inexistente", "Título", null, null, PROF_ID));
+        assertTrue(ex.getMessage().contains("Tarea no encontrada"));
+    }
+
+    @Test
+    @DisplayName("CP-TASK-003 | Lanza AppException si el profesor no es el autor (RNF-06)")
+    void update_throwsOnWrongProfessor() {
+        Task original = service.create("Tarea", null, null, MATERIA_MAT, PROF_ID);
+        AppException ex = assertThrows(AppException.class, () ->
+                service.update(original.getId(), "Nuevo título", null, null, OTRO_PROF_ID));
+        assertEquals("No tienes permiso para editar esta tarea.", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-003 | Lanza AppException si el nuevo título está vacío")
+    void update_throwsOnEmptyTitulo() {
+        Task original = service.create("Tarea", null, null, MATERIA_MAT, PROF_ID);
+        AppException ex = assertThrows(AppException.class, () ->
+                service.update(original.getId(), "", null, null, PROF_ID));
+        assertEquals("El título es obligatorio.", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-003 | Lanza AppException si la nueva fecha tiene formato inválido")
+    void update_throwsOnInvalidDate() {
+        Task original = service.create("Examen", null, null, MATERIA_MAT, PROF_ID);
+        AppException ex = assertThrows(AppException.class, () ->
+                service.update(original.getId(), "Examen", null, "31/12/2025", PROF_ID));
+        assertTrue(ex.getMessage().contains("Formato de fecha inválido"));
+    }
+
+    @Test
+    @DisplayName("CP-TASK-004 | S1 | Elimina tarea sin notas — no aparece en la lista")
+    void delete_noGrades_removedFromList() {
+        Task tarea = service.create("Quiz de ortografía", null, null, MATERIA_ESP, PROF_ID);
+        service.delete(tarea.getId(), PROF_ID);
+        assertTrue(service.listBySubject(MATERIA_ESP, PROF_ID).isEmpty());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-004 | S1 | Elimina tarea sin notas — se borra de tasks.json")
+    void delete_noGrades_removedFromJson() {
+        Task tarea = service.create("Quiz de ortografía", null, null, MATERIA_ESP, PROF_ID);
+        service.delete(tarea.getId(), PROF_ID);
+        assertTrue(JsonFileManager.readAll("tasks.json", Task.class).isEmpty());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-004 | S1 | countGradesByTask devuelve 0 sin notas")
+    void countGrades_returnsZero() {
+        Task tarea = service.create("Quiz sin notas", null, null, MATERIA_ESP, PROF_ID);
+        assertEquals(0, service.countGradesByTask(tarea.getId()));
+    }
+
+    @Test
+    @DisplayName("CP-TASK-004 | S2 | countGradesByTask cuenta 10 notas correctamente")
+    void countGrades_returnsTen() {
+        Task tarea = service.create("Parcial 1", null, null, MATERIA_ESP, PROF_ID);
+        crearNotasEnArchivo(tarea.getId(), 10);
+        assertEquals(10, service.countGradesByTask(tarea.getId()));
+    }
+
+    @Test
+    @DisplayName("CP-TASK-004 | S2 | Elimina tarea con notas y borra las notas en cascada (RN-09b)")
+    void delete_withGrades_cascadeDeletesGrades() {
+        Task tarea = service.create("Parcial 1", null, null, MATERIA_ESP, PROF_ID);
+        crearNotasEnArchivo(tarea.getId(), 10);
+
+        service.delete(tarea.getId(), PROF_ID);
+
+        assertTrue(JsonFileManager.readAll("tasks.json", Task.class).isEmpty());
+        assertEquals(0, service.countGradesByTask(tarea.getId()));
+    }
+
+    @Test
+    @DisplayName("CP-TASK-004 | S2 | Solo elimina notas de la tarea borrada, no las de otras")
+    void delete_onlyDeletesTargetTaskGrades() {
+        Task tarea1 = service.create("Parcial 1", null, null, MATERIA_ESP, PROF_ID);
+        Task tarea2 = service.create("Parcial 2", null, null, MATERIA_ESP, PROF_ID);
+        crearNotasEnArchivo(tarea1.getId(), 3);
+        crearNotasEnArchivo(tarea2.getId(), 3);
+
+        service.delete(tarea1.getId(), PROF_ID);
+
+        assertEquals(3, service.countGradesByTask(tarea2.getId()),
+                "Las notas de otras tareas deben permanecer intactas");
+    }
+
+    @Test
+    @DisplayName("CP-TASK-004 | Lanza AppException si la tarea no existe")
+    void delete_throwsOnNonExistentTask() {
+        AppException ex = assertThrows(AppException.class, () ->
+                service.delete("id-inexistente", PROF_ID));
+        assertTrue(ex.getMessage().contains("Tarea no encontrada"));
+    }
+
+    @Test
+    @DisplayName("CP-TASK-004 | Lanza AppException si el profesor no es el autor (RNF-06)")
+    void delete_throwsOnWrongProfessor() {
+        Task tarea = service.create("Tarea protegida", null, null, MATERIA_MAT, PROF_ID);
+        AppException ex = assertThrows(AppException.class, () ->
+                service.delete(tarea.getId(), OTRO_PROF_ID));
+        assertEquals("No tienes permiso para eliminar esta tarea.", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("CP-TASK-004 | Si falla la autorización, las notas no se tocan")
+    void delete_authFailure_gradesUntouched() {
+        Task tarea = service.create("Tarea protegida", null, null, MATERIA_MAT, PROF_ID);
+        crearNotasEnArchivo(tarea.getId(), 5);
+
+        assertThrows(AppException.class, () -> service.delete(tarea.getId(), OTRO_PROF_ID));
+
+        assertEquals(5, service.countGradesByTask(tarea.getId()),
+                "Las notas no deben borrarse si la autorización falla");
+    }
+
+
+    private void crearNotasEnArchivo(String tareaId, int cantidad) {
+        List<Map> notas = new ArrayList<>(JsonFileManager.readAll("grades.json", Map.class));
+        for (int i = 0; i < cantidad; i++) {
+            Map<String, Object> nota = new HashMap<>();
+            nota.put("id",           "grade-" + tareaId + "-" + i);
+            nota.put("tareaId",      tareaId);
+            nota.put("estudianteId", "est-" + i);
+            nota.put("materiaId",    MATERIA_ESP);
+            nota.put("valor",        4.0);
+            nota.put("profesorId",   PROF_ID);
+            notas.add(nota);
+        }
+        JsonFileManager.writeAll("grades.json", notas);
+    }
+
+    private void deleteRecursively(java.io.File dir) throws IOException {
+        if (dir.isDirectory()) {
+            for (java.io.File child : dir.listFiles()) deleteRecursively(child);
+        }
+        dir.delete();
     }
 }


### PR DESCRIPTION
agrega TaskController para la interfaz de usuario de gestión de tareas (#16)

Implementa la capa de interacción de consola para las operaciones CRUD de tareas,
cubriendo HU-TASK-01 a HU-TASK-04 (ISSUE-015 e ISSUE-016).

mostrarMenu(scanner, profesorId):

Bucle con interruptor que redirige a métodos de flujo privados.

Opciones: 1. Crear 2. Listar 3. Editar 4. Eliminar 5. Atrás

flujoCrear() — HU-TASK-01 / CP-TASK-001:

Muestra la lista de asignaturas numeradas → el profesor elige una asignatura →

lee el título (obligatorio), la descripción y la fecha (opcional) →

llama a service.create() → imprime los detalles de la tarea si se completa con éxito.

flujoListar() — HU-TASK-02 / CP-TASK-002:

El profesor elige una asignatura → llama a service.create() servicio.listBySubject() →
  imprime tabla: ID | TÍTULO | FECHA LÍMITE
  Muestra '(No tienes tareas en esta materia)' si está vacío.
 
flujoEditar() — HU-TASK-03 / CP-TASK-003:
  El profesor ingresa el ID de la tarea → lee el nuevo título, descripción y fecha →
  llama a service.update() → imprime 'Tarea actualizada correctamente.'
  El mensaje exacto coincide con los criterios de aceptación de CP-TASK-003.

flujoEliminar() — HU-TASK-04 / CP-TASK-004:

Llama a service.countGradesByTask() antes de eliminar.

Si grades > 0: advierte 'Esta tarea tiene N nota(s). Se eliminarán también. ¿Continuar? (s/n)'

Si grades == 0: simple 'Confirmar eliminación? (s/n)'

Solo llama a service.delete() tras una confirmación explícita con 's'.

El formato exacto de la advertencia coincide con el escenario 2 de CP-TASK-004.

Dependencia de SubjectService:

Aún no disponible (ISSUE-012 / @dev2). Reemplazada por obtenerMaterias()

un stub que devuelve las 5 asignaturas predeterminadas. Documentado con un comentario TODO

que muestra el código exacto a reemplazar cuando se fusione ISSUE-012.

leerOpcion(): análisis seguro de enteros: devuelve -1 en entradas no numéricas.

Todos Se detectó una excepción de aplicación por flujo, que se muestra con un prefijo de error.

Relacionado con el número 16.