### PR TITLE
feat(professor): ISSUE-028 — HU-PROF-02: Admin lista profesores

### DIFF
--- a/src/main/java/org/manageSchool/professor/ProfessorController.java
+++ b/src/main/java/org/manageSchool/professor/ProfessorController.java
@@ -40,7 +40,7 @@ public class ProfessorController {
 
             switch (opcion) {
                 case 1 -> crearProfesor(scanner);
-                case 2 -> System.out.println("listarProfesores();");
+                case 2 -> listarProfesores();
                 case 3 -> activo = false;
                 default -> System.out.println("  Opción inválida.");
             }
@@ -68,6 +68,25 @@ public class ProfessorController {
             System.out.println("    Rol:    " + profesor.getRol());
         } catch (AppException e) {
             System.out.println("  Error: " + e.getMessage());
+        }
+    }
+
+    // ISSUE-028 / CP-PROF-002: muestra la lista de profesores registrados.
+    private void listarProfesores() {
+        List<Professor> profesores = service.listAllSorted();
+
+        if (profesores.isEmpty()) {
+            System.out.println("  No hay profesores registrados.");
+            return;
+        }
+
+        System.out.println("\n  ===== LISTA DE PROFESORES =====");
+        System.out.printf("  Total: %d profesor(es)%n%n", profesores.size());
+        int i = 1;
+        for (Professor p : profesores) {
+            String estado = p.isActivo() ? "Activo" : "Inactivo";
+            System.out.printf("  %d. %s | %s | %s%n",
+                    i++, p.getNombre(), p.getCorreo(), estado);
         }
     }
 }

--- a/src/main/java/org/manageSchool/professor/ProfessorService.java
+++ b/src/main/java/org/manageSchool/professor/ProfessorService.java
@@ -43,4 +43,12 @@ public class ProfessorService {
     public List<Professor> listAll () {
         return repo.findAll();
     }
+
+    // ISSUE-028 / CP-PROF-002: lista profesores ordenados alfabéticamente por nombre
+    public List<Professor> listAllSorted() {
+        return repo.findAll().stream()
+                .sorted(java.util.Comparator.comparing(
+                        p -> p.getNombre() == null ? "" : p.getNombre().toLowerCase()))
+                .toList();
+    }
 }

--- a/src/test/java/org/manageSchool/professor/ProfessorRepositoryTest.java
+++ b/src/test/java/org/manageSchool/professor/ProfessorRepositoryTest.java
@@ -1,0 +1,72 @@
+package org.manageSchool.professor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.manageSchool.auth.AuthRepository;
+import org.manageSchool.auth.User;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ProfessorRepositoryTest {
+
+    private AuthRepository authRepoMock;
+    private ProfessorRepository repo;
+
+    @BeforeEach
+    void setUp() {
+        authRepoMock = mock(AuthRepository.class);
+        repo = new ProfessorRepository(authRepoMock);
+    }
+
+    @Test
+    @DisplayName("CP-PROF-002: findAll filtra únicamente usuarios con rol = PROFESOR")
+    void findAll_filtraSoloProfesores() {
+        User profesor1 = User.crear("Laura", "laura@colegio.edu.co", "h", "PROFESOR");
+        User profesor2 = User.crear("Carlos", "carlos@colegio.edu.co", "h", "PROFESOR");
+        when(authRepoMock.findByRole("PROFESOR")).thenReturn(List.of(profesor1, profesor2));
+
+        List<Professor> resultado = repo.findAll();
+
+        assertEquals(2, resultado.size());
+        assertTrue(resultado.stream().allMatch(p -> "PROFESOR".equals(p.getRol())));
+        verify(authRepoMock, times(1)).findByRole("PROFESOR");
+    }
+
+    @Test
+    @DisplayName("CP-PROF-002: findAll devuelve lista vacía si no hay profesores")
+    void findAll_devuelveListaVaciaSiNoHayProfesores() {
+        when(authRepoMock.findByRole("PROFESOR")).thenReturn(List.of());
+
+        List<Professor> resultado = repo.findAll();
+
+        assertTrue(resultado.isEmpty());
+    }
+
+    @Test
+    @DisplayName("findByCorreo devuelve profesor si existe y tiene rol PROFESOR")
+    void findByCorreo_devuelveProfesorSiExiste() {
+        User profesor = User.crear("Laura", "laura@colegio.edu.co", "h", "PROFESOR");
+        when(authRepoMock.findByEmail("laura@colegio.edu.co")).thenReturn(Optional.of(profesor));
+
+        Optional<Professor> resultado = repo.findByCorreo("laura@colegio.edu.co");
+
+        assertTrue(resultado.isPresent());
+        assertEquals("Laura", resultado.get().getNombre());
+    }
+
+    @Test
+    @DisplayName("findByCorreo devuelve vacío si el usuario existe pero no es profesor")
+    void findByCorreo_devuelveVacioSiNoEsProfesor() {
+        User admin = User.crear("Admin", "admin@colegio.edu.co", "h", "ADMIN");
+        when(authRepoMock.findByEmail("admin@colegio.edu.co")).thenReturn(Optional.of(admin));
+
+        Optional<Professor> resultado = repo.findByCorreo("admin@colegio.edu.co");
+
+        assertTrue(resultado.isEmpty());
+    }
+}

--- a/src/test/java/org/manageSchool/professor/ProfessorServiceTest.java
+++ b/src/test/java/org/manageSchool/professor/ProfessorServiceTest.java
@@ -100,4 +100,47 @@ public class ProfessorServiceTest {
 
         assertEquals("El nombre no puede estar vacío.", ex.getMessage());
     }
+
+    // ===== ISSUE-028 / CP-PROF-002: Listar profesores =====
+
+    @Test
+    @DisplayName("CP-PROF-002: Lista con profesores registrados devuelve todos ordenados por nombre")
+    void listAllSorted_devuelveProfesoresOrdenadosPorNombre() {
+        User u1 = User.crear("Zulema Ríos", "zulema@colegio.edu.co", "h", Professor.ROL);
+        User u2 = User.crear("Ana López", "ana@colegio.edu.co", "h", Professor.ROL);
+        User u3 = User.crear("Marta Díaz", "marta@colegio.edu.co", "h", Professor.ROL);
+        when(repoMock.findAll()).thenReturn(List.of(
+                new Professor(u1), new Professor(u2), new Professor(u3)));
+
+        List<Professor> resultado = service.listAllSorted();
+
+        assertEquals(3, resultado.size());
+        assertEquals("Ana López",   resultado.get(0).getNombre());
+        assertEquals("Marta Díaz",  resultado.get(1).getNombre());
+        assertEquals("Zulema Ríos", resultado.get(2).getNombre());
+    }
+
+    @Test
+    @DisplayName("CP-PROF-002: Lista vacía de profesores devuelve colección vacía")
+    void listAllSorted_devuelveListaVaciaSiNoHayProfesores() {
+        when(repoMock.findAll()).thenReturn(List.of());
+
+        List<Professor> resultado = service.listAllSorted();
+
+        assertTrue(resultado.isEmpty());
+        verify(repoMock, times(1)).findAll();
+    }
+
+    @Test
+    @DisplayName("CP-PROF-002: Ordenamiento es case-insensitive")
+    void listAllSorted_ordenaIgnorandoMayusculas() {
+        User u1 = User.crear("ZULEMA", "zulema@colegio.edu.co", "h", Professor.ROL);
+        User u2 = User.crear("ana", "ana@colegio.edu.co", "h", Professor.ROL);
+        when(repoMock.findAll()).thenReturn(List.of(new Professor(u1), new Professor(u2)));
+
+        List<Professor> resultado = service.listAllSorted();
+
+        assertEquals("ana", resultado.get(0).getNombre());
+        assertEquals("ZULEMA", resultado.get(1).getNombre());
+    }
 }


### PR DESCRIPTION
## Issue
Closes #13 — ISSUE-028 — HU-PROF-02: Admin lista profesores

## Descripción
Implementa el listado de profesores desde el menú del administrador.
El repositorio filtra por `rol = PROFESOR` (única fuente de verdad:
`users.json`), el servicio ordena alfabéticamente por nombre, y el
controlador muestra el total junto con una lista numerada.

## Cambios
- `ProfessorService.listAllSorted()`: nuevo método que ordena por nombre
  (case-insensitive)
- `ProfessorController.listarProfesores()`: implementación real del case 2
  del submenú (antes era un placeholder)
- `ProfessorServiceTest`: 3 tests nuevos para ordenamiento y lista vacía
- `ProfessorRepositoryTest`: archivo nuevo con 4 tests para filtrado por rol

## Criterios de aceptación cubiertos
- [x] Muestra nombre, correo y estado (activo) de cada profesor
- [x] Filtra únicamente usuarios con `rol = PROFESOR`
- [x] Si no hay profesores registrados, muestra "No hay profesores registrados"
- [x] Casos de prueba: CP-PROF-002 (ambos escenarios Gherkin)

## Cómo probar
1. `mvn test` → +7 tests en verde
2. `mvn exec:java` → admin@colegio.edu.co / Admin2026 → menú 2 → opción 2
   - Sin profesores: "No hay profesores registrados"
   - Con profesores creados: lista numerada ordenada alfabéticamente