### PR TITLE
feat(professor): ISSUE-029 — HU-PROF-03: Admin edita profesor

### DIFF
--- a/src/main/java/org/manageSchool/professor/ProfessorController.java
+++ b/src/main/java/org/manageSchool/professor/ProfessorController.java
@@ -26,7 +26,8 @@ public class ProfessorController {
             System.out.println("\n  ===== GESTIONAR PROFESORES =====");
             System.out.println("  1. Crear profesor");
             System.out.println("  2. Listar profesores");
-            System.out.println("  3. Volver");
+            System.out.println("  3. Editar profesor");
+            System.out.println("  4. Volver");
             System.out.print("  Seleccione una opción: ");
 
             String linea = scanner.nextLine().trim();
@@ -41,7 +42,8 @@ public class ProfessorController {
             switch (opcion) {
                 case 1 -> crearProfesor(scanner);
                 case 2 -> listarProfesores();
-                case 3 -> activo = false;
+                case 3 -> editarProfesor(scanner);
+                case 4 -> activo = false;
                 default -> System.out.println("  Opción inválida.");
             }
         }
@@ -87,6 +89,62 @@ public class ProfessorController {
             String estado = p.isActivo() ? "Activo" : "Inactivo";
             System.out.printf("  %d. %s | %s | %s%n",
                     i++, p.getNombre(), p.getCorreo(), estado);
+        }
+    }
+    // ISSUE-029 / CP-PROF-003: edita nombre y/o correo de un profesor existente.
+    private void editarProfesor(Scanner scanner) {
+        System.out.println("\n  ===== EDITAR PROFESOR =====");
+
+        List<Professor> profesores = service.listAllSorted();
+        if (profesores.isEmpty()) {
+            System.out.println("  No hay profesores registrados para editar.");
+            return;
+        }
+
+        // Mostrar lista numerada para que el admin elija
+        System.out.println("  Seleccione el profesor a editar:");
+        int i = 1;
+        for (Professor p : profesores) {
+            System.out.printf("  %d. %s | %s%n", i++, p.getNombre(), p.getCorreo());
+        }
+        System.out.println("  0. Cancelar");
+        System.out.print("  Opción: ");
+
+        int seleccion;
+        try {
+            seleccion = Integer.parseInt(scanner.nextLine().trim());
+        } catch (NumberFormatException e) {
+            System.out.println("  Opción inválida.");
+            return;
+        }
+
+        if (seleccion == 0) {
+            System.out.println("  Edición cancelada.");
+            return;
+        }
+        if (seleccion < 1 || seleccion > profesores.size()) {
+            System.out.println("  Opción fuera de rango.");
+            return;
+        }
+
+        Professor objetivo = profesores.get(seleccion - 1);
+
+        System.out.println("\n  Dejando un campo vacío se conserva el valor actual.");
+        System.out.printf("  Nombre actual: %s%n", objetivo.getNombre());
+        System.out.print("  Nuevo nombre: ");
+        String nuevoNombre = scanner.nextLine().trim();
+
+        System.out.printf("  Correo actual: %s%n", objetivo.getCorreo());
+        System.out.print("  Nuevo correo (@colegio.edu.co): ");
+        String nuevoCorreo = scanner.nextLine().trim();
+
+        try {
+            Professor actualizado = service.update(objetivo.getId(), nuevoNombre, nuevoCorreo);
+            System.out.println("  Profesor actualizado correctamente.");
+            System.out.printf("    Nombre: %s%n", actualizado.getNombre());
+            System.out.printf("    Correo: %s%n", actualizado.getCorreo());
+        } catch (AppException e) {
+            System.out.println("  Error: " + e.getMessage());
         }
     }
 }

--- a/src/main/java/org/manageSchool/professor/ProfessorRepository.java
+++ b/src/main/java/org/manageSchool/professor/ProfessorRepository.java
@@ -51,5 +51,9 @@ public class ProfessorRepository{
         return findByCorreo(correo).isPresent();
     }
 
+    // Exposición controlada del AuthRepository subyacente para operaciones de escritura
+    public org.manageSchool.auth.AuthRepository getAuthRepository() {
+        return this.authRepository;
+    }
 
 }

--- a/src/main/java/org/manageSchool/professor/ProfessorService.java
+++ b/src/main/java/org/manageSchool/professor/ProfessorService.java
@@ -51,4 +51,64 @@ public class ProfessorService {
                         p -> p.getNombre() == null ? "" : p.getNombre().toLowerCase()))
                 .toList();
     }
+
+    /**
+     * Edita un profesor existente. Solo se permiten cambios en nombre y correo.
+     *
+     * Si un campo viene null o vacío, se conserva el valor actual.
+     * Reglas (CP-PROF-003):
+     *  - El nuevo correo debe seguir siendo @colegio.edu.co
+     *  - El nuevo correo no puede estar en uso por otro usuario (cualquier rol)
+     *
+     * @param id            ID del profesor a editar
+     * @param nuevoNombre   Nuevo nombre (null o vacío para conservar el actual)
+     * @param nuevoCorreo   Nuevo correo (null o vacío para conservar el actual)
+     * @return el Professor ya actualizado
+     */
+    public Professor update(String id, String nuevoNombre, String nuevoCorreo) {
+        // 1) Buscar el profesor existente
+        Professor profesor = repo.findById(id)
+                .orElseThrow(() -> new org.manageSchool.shared.AppException(
+                        "Profesor no encontrado."));
+
+        User user = profesor.getUser();
+
+        // 2) Actualizar nombre si se proporcionó
+        if (org.manageSchool.shared.util.Validator.isNotEmpty(nuevoNombre)) {
+            user.setNombre(nuevoNombre.trim());
+        }
+
+        // 3) Actualizar correo si se proporcionó (con validaciones)
+        if (org.manageSchool.shared.util.Validator.isNotEmpty(nuevoCorreo)) {
+            String correoNormalizado = nuevoCorreo.trim();
+
+            // Validar dominio institucional
+            if (!org.manageSchool.shared.util.Validator.isValidEmail(correoNormalizado)) {
+                throw new org.manageSchool.shared.AppException(
+                        "El correo debe pertenecer al dominio @colegio.edu.co.");
+            }
+
+            // Validar que no esté en uso por OTRO usuario (cualquier rol)
+            // Si es el mismo correo que ya tenía el profesor, no hay conflicto.
+            if (!correoNormalizado.equalsIgnoreCase(user.getCorreo())) {
+                java.util.Optional<User> existente =
+                        authRepository().findByEmail(correoNormalizado);
+                if (existente.isPresent() && !existente.get().getId().equals(user.getId())) {
+                    throw new org.manageSchool.shared.AppException(
+                            "El correo ya está en uso por otro usuario.");
+                }
+                user.setCorreo(correoNormalizado);
+            }
+        }
+
+        // 4) Persistir en users.json (fuente de verdad única)
+        authRepository().update(user);
+
+        return new Professor(user);
+    }
+
+    // Helper para obtener el AuthRepository desde el ProfessorRepository
+    private org.manageSchool.auth.AuthRepository authRepository() {
+        return repo.getAuthRepository();
+    }
 }

--- a/src/test/java/org/manageSchool/professor/ProfessorServiceTest.java
+++ b/src/test/java/org/manageSchool/professor/ProfessorServiceTest.java
@@ -3,6 +3,7 @@ package org.manageSchool.professor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.manageSchool.auth.AuthRepository;
 import org.manageSchool.auth.AuthService;
 import org.manageSchool.auth.CreateUserRequest;
 import org.manageSchool.auth.User;
@@ -16,6 +17,7 @@ import static org.mockito.Mockito.*;
 
 public class ProfessorServiceTest {
 
+    private AuthRepository authRepoMock;
     private ProfessorRepository repoMock;
     private AuthService authServiceMock;
     private ProfessorService service;
@@ -24,6 +26,8 @@ public class ProfessorServiceTest {
     void setUp() {
         repoMock = mock(ProfessorRepository.class);
         authServiceMock = mock(AuthService.class);
+        authRepoMock = mock(AuthRepository.class);
+        when(repoMock.getAuthRepository()).thenReturn(authRepoMock);
         service = new ProfessorService(repoMock, authServiceMock);
     }
 
@@ -142,5 +146,98 @@ public class ProfessorServiceTest {
 
         assertEquals("ana", resultado.get(0).getNombre());
         assertEquals("ZULEMA", resultado.get(1).getNombre());
+    }
+
+    // ===== ISSUE-029 / CP-PROF-003: Editar profesor =====
+
+    @Test
+    @DisplayName("CP-PROF-003: Edita nombre exitosamente")
+    void update_editaNombreExitosamente() {
+        User user = User.crear("Pedro Ruiz", "pedro@colegio.edu.co", "h", Professor.ROL);
+        when(repoMock.findById(user.getId())).thenReturn(java.util.Optional.of(new Professor(user)));
+
+        Professor actualizado = service.update(user.getId(), "Pedro Ruiz Montoya", "");
+
+        assertEquals("Pedro Ruiz Montoya", actualizado.getNombre());
+        assertEquals("pedro@colegio.edu.co", actualizado.getCorreo()); // correo no cambia
+        verify(authRepoMock, times(1)).update(user);
+    }
+
+    @Test
+    @DisplayName("CP-PROF-003: Edita correo exitosamente cuando no está en uso")
+    void update_editaCorreoExitosamente() {
+        User user = User.crear("Pedro", "pedro@colegio.edu.co", "h", Professor.ROL);
+        when(repoMock.findById(user.getId())).thenReturn(java.util.Optional.of(new Professor(user)));
+        when(authRepoMock.findByEmail("pedro.nuevo@colegio.edu.co"))
+                .thenReturn(java.util.Optional.empty());
+
+        Professor actualizado = service.update(user.getId(), "", "pedro.nuevo@colegio.edu.co");
+
+        assertEquals("pedro.nuevo@colegio.edu.co", actualizado.getCorreo());
+        verify(authRepoMock, times(1)).update(user);
+    }
+
+    @Test
+    @DisplayName("CP-PROF-003: Rechaza cambio de correo a uno ya registrado por otro usuario")
+    void update_rechazaCorreoDuplicadoDeOtroUsuario() {
+        User profesor = User.crear("Pedro", "pedro@colegio.edu.co", "h", Professor.ROL);
+        User otroUsuario = User.crear("Otro", "otro@colegio.edu.co", "h", Professor.ROL);
+        when(repoMock.findById(profesor.getId()))
+                .thenReturn(java.util.Optional.of(new Professor(profesor)));
+        when(authRepoMock.findByEmail("otro@colegio.edu.co"))
+                .thenReturn(java.util.Optional.of(otroUsuario));
+
+        AppException ex = assertThrows(AppException.class,
+                () -> service.update(profesor.getId(), "", "otro@colegio.edu.co"));
+
+        assertEquals("El correo ya está en uso por otro usuario.", ex.getMessage());
+        verify(authRepoMock, never()).update(any(User.class));
+    }
+
+    @Test
+    @DisplayName("CP-PROF-003: Permite mantener el mismo correo (no es duplicado consigo mismo)")
+    void update_permiteMismoCorreo() {
+        User user = User.crear("Pedro", "pedro@colegio.edu.co", "h", Professor.ROL);
+        when(repoMock.findById(user.getId())).thenReturn(java.util.Optional.of(new Professor(user)));
+
+        assertDoesNotThrow(() ->
+                service.update(user.getId(), "Pedro Nuevo", "pedro@colegio.edu.co"));
+    }
+
+    @Test
+    @DisplayName("CP-PROF-003: Rechaza correo no institucional")
+    void update_rechazaCorreoNoInstitucional() {
+        User user = User.crear("Pedro", "pedro@colegio.edu.co", "h", Professor.ROL);
+        when(repoMock.findById(user.getId())).thenReturn(java.util.Optional.of(new Professor(user)));
+
+        AppException ex = assertThrows(AppException.class,
+                () -> service.update(user.getId(), "", "pedro@gmail.com"));
+
+        assertEquals("El correo debe pertenecer al dominio @colegio.edu.co.", ex.getMessage());
+        verify(authRepoMock, never()).update(any(User.class));
+    }
+
+    @Test
+    @DisplayName("CP-PROF-003: Lanza error si el profesor no existe")
+    void update_lanzaErrorSiProfesorNoExiste() {
+        when(repoMock.findById("no-existe")).thenReturn(java.util.Optional.empty());
+
+        AppException ex = assertThrows(AppException.class,
+                () -> service.update("no-existe", "Nuevo", ""));
+
+        assertEquals("Profesor no encontrado.", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("CP-PROF-003: Si ambos campos están vacíos, no cambia nada pero persiste")
+    void update_camposVaciosConservanValoresActuales() {
+        User user = User.crear("Pedro", "pedro@colegio.edu.co", "h", Professor.ROL);
+        when(repoMock.findById(user.getId())).thenReturn(java.util.Optional.of(new Professor(user)));
+
+        Professor actualizado = service.update(user.getId(), "", "");
+
+        assertEquals("Pedro", actualizado.getNombre());
+        assertEquals("pedro@colegio.edu.co", actualizado.getCorreo());
+        verify(authRepoMock, times(1)).update(user);
     }
 }


### PR DESCRIPTION
## Issue
Closes #14 — ISSUE-029 — HU-PROF-03: Admin edita profesor

## Descripción
Implementa la edición de nombre y correo de un profesor existente desde el
menú del administrador. La edición actualiza el `User` subyacente en
`users.json` vía `AuthRepository.update`, manteniendo la fuente de verdad única.

## Cambios
- `ProfessorService.update(id, nuevoNombre, nuevoCorreo)`:
  - Campos vacíos conservan el valor actual
  - Valida dominio `@colegio.edu.co` si se cambia el correo
  - Valida unicidad del correo contra todos los usuarios (cualquier rol)
  - Permite conservar el mismo correo sin marcarlo como duplicado
- `ProfessorRepository.getAuthRepository()`: expone el `AuthRepository`
  subyacente para operaciones de escritura
- `ProfessorController`:
  - Nueva opción 3 "Editar profesor" (Volver pasa a opción 4)
  - Método `editarProfesor`: lista profesores numerados, permite elegir y
    editar, muestra "Profesor actualizado correctamente"
- `ProfessorServiceTest`: 7 tests nuevos cubriendo CP-PROF-003

## Criterios de aceptación cubiertos
- [x] Permite editar: nombre y correo
- [x] No permite cambiar el correo por uno ya registrado (cualquier rol)
- [x] El correo editado debe seguir siendo `@colegio.edu.co`
- [x] Confirma los cambios con mensaje de éxito
- [x] Casos de prueba: CP-PROF-003 (ambos escenarios Gherkin)

## Cómo probar
1. `mvn test` → +7 tests nuevos en verde
2. `mvn exec:java` → admin@colegio.edu.co / Admin2026 → menú 2 → opción 3
   - Crear un par de profesores primero para poder editar
   - Editar nombre: éxito
   - Editar correo a uno no usado: éxito
   - Editar correo a uno ya en uso: error esperado
   - Editar correo con dominio incorrecto: error esperado