### PR TITLE
feat(professor): ISSUE-030 — HU-PROF-04: Admin elimina profesor

### DIFF
--- a/src/main/java/org/manageSchool/professor/ProfessorController.java
+++ b/src/main/java/org/manageSchool/professor/ProfessorController.java
@@ -15,7 +15,9 @@ public class ProfessorController {
         AuthRepository authRepo = new AuthRepository();
         AuthService authService = new AuthService(authRepo);
         ProfessorRepository repo = new ProfessorRepository(authRepo);
-        this.service = new ProfessorService(repo, authService);
+        this.service = new ProfessorService(repo, authService,
+                new org.manageSchool.task.TaskRepository(),
+                new org.manageSchool.grade.GradeRepository());
     }
 
     // submenu de gestión de profesores (rol ADMIN)

--- a/src/main/java/org/manageSchool/professor/ProfessorController.java
+++ b/src/main/java/org/manageSchool/professor/ProfessorController.java
@@ -29,7 +29,8 @@ public class ProfessorController {
             System.out.println("  1. Crear profesor");
             System.out.println("  2. Listar profesores");
             System.out.println("  3. Editar profesor");
-            System.out.println("  4. Volver");
+            System.out.println("  4. Eliminar profesor");
+            System.out.println("  5. Volver");
             System.out.print("  Seleccione una opción: ");
 
             String linea = scanner.nextLine().trim();
@@ -45,7 +46,8 @@ public class ProfessorController {
                 case 1 -> crearProfesor(scanner);
                 case 2 -> listarProfesores();
                 case 3 -> editarProfesor(scanner);
-                case 4 -> activo = false;
+                case 4 -> eliminarProfesor(scanner);
+                case 5 -> activo = false;
                 default -> System.out.println("  Opción inválida.");
             }
         }
@@ -145,6 +147,76 @@ public class ProfessorController {
             System.out.println("  Profesor actualizado correctamente.");
             System.out.printf("    Nombre: %s%n", actualizado.getNombre());
             System.out.printf("    Correo: %s%n", actualizado.getCorreo());
+        } catch (AppException e) {
+            System.out.println("  Error: " + e.getMessage());
+        }
+    }
+    // ISSUE-030 / CP-PROF-004, CP-PROF-005: elimina un profesor con confirmación.
+    private void eliminarProfesor(Scanner scanner) {
+        System.out.println("\n  ===== ELIMINAR PROFESOR =====");
+
+        List<Professor> profesores = service.listAllSorted();
+        if (profesores.isEmpty()) {
+            System.out.println("  No hay profesores registrados para eliminar.");
+            return;
+        }
+
+        // Mostrar lista numerada
+        System.out.println("  Seleccione el profesor a eliminar:");
+        int i = 1;
+        for (Professor p : profesores) {
+            System.out.printf("  %d. %s | %s%n", i++, p.getNombre(), p.getCorreo());
+        }
+        System.out.println("  0. Cancelar");
+        System.out.print("  Opción: ");
+
+        int seleccion;
+        try {
+            seleccion = Integer.parseInt(scanner.nextLine().trim());
+        } catch (NumberFormatException e) {
+            System.out.println("  Opción inválida.");
+            return;
+        }
+
+        if (seleccion == 0) {
+            System.out.println("  Eliminación cancelada.");
+            return;
+        }
+        if (seleccion < 1 || seleccion > profesores.size()) {
+            System.out.println("  Opción fuera de rango.");
+            return;
+        }
+
+        Professor objetivo = profesores.get(seleccion - 1);
+
+        try {
+            // Obtener info de tareas y notas asociadas
+            int[] info = service.getDeletionInfo(objetivo.getId());
+            int tareas = info[0];
+            int notas  = info[1];
+
+            // CP-PROF-004: aviso si tiene tareas asociadas
+            if (tareas > 0) {
+                System.out.printf(
+                        "  Este profesor tiene %d tarea(s) y %d nota(s) asociadas.%n",
+                        tareas, notas);
+                System.out.println("  Al eliminarlo, quedarán huérfanas. ¿Desea continuar?");
+            } else {
+                System.out.printf("  ¿Está seguro de eliminar a %s?%n", objetivo.getNombre());
+            }
+
+            System.out.print("  Escriba 'SI' para confirmar: ");
+            String confirmacion = scanner.nextLine().trim();
+
+            if (!confirmacion.equalsIgnoreCase("SI")) {
+                System.out.println("  Eliminación cancelada.");
+                return;
+            }
+
+            // Eliminar (tareas y notas se conservan intactas - RN-10)
+            service.delete(objetivo.getId());
+            System.out.println("  Profesor eliminado correctamente.");
+
         } catch (AppException e) {
             System.out.println("  Error: " + e.getMessage());
         }

--- a/src/main/java/org/manageSchool/professor/ProfessorService.java
+++ b/src/main/java/org/manageSchool/professor/ProfessorService.java
@@ -1,5 +1,10 @@
 package org.manageSchool.professor;
 
+import org.manageSchool.task.TaskRepository;
+import org.manageSchool.task.Task;
+import org.manageSchool.grade.GradeRepository;
+import org.manageSchool.grade.Grade;
+import org.manageSchool.shared.AppException;
 import org.manageSchool.auth.AuthService;
 import org.manageSchool.auth.CreateUserRequest;
 import org.manageSchool.auth.User;
@@ -18,10 +23,21 @@ public class ProfessorService {
 
     private final ProfessorRepository repo;
     private final AuthService authService;
+    private final TaskRepository taskRepo;
+    private final GradeRepository gradeRepo;
 
-    public ProfessorService(ProfessorRepository repo, AuthService authService) {
+    // Constructor completo (ISSUE-030 requiere acceso a tareas y notas)
+    public ProfessorService(ProfessorRepository repo, AuthService authService,
+                            TaskRepository taskRepo, GradeRepository gradeRepo) {
         this.repo = repo;
         this.authService = authService;
+        this.taskRepo = taskRepo;
+        this.gradeRepo = gradeRepo;
+    }
+
+    // Constructor retrocompatible (para código que no necesita delete)
+    public ProfessorService(ProfessorRepository repo, AuthService authService) {
+        this(repo, authService, new TaskRepository(), new GradeRepository());
     }
 
     /**
@@ -110,5 +126,39 @@ public class ProfessorService {
     // Helper para obtener el AuthRepository desde el ProfessorRepository
     private org.manageSchool.auth.AuthRepository authRepository() {
         return repo.getAuthRepository();
+    }
+
+    /**
+     * Cuenta tareas y notas asociadas a un profesor antes de eliminar.
+     * Retorna un array: [cantidadTareas, cantidadNotas]
+     */
+    public int[] getDeletionInfo(String profesorId) {
+        Professor profesor = repo.findById(profesorId)
+                .orElseThrow(() -> new AppException("Profesor no encontrado."));
+
+        List<Task> tareas = taskRepo.findByProfessorId(profesor.getId());
+        int totalNotas = 0;
+        for (Task t : tareas) {
+            totalNotas += gradeRepo.findByTaskId(t.getId()).size();
+        }
+
+        return new int[]{ tareas.size(), totalNotas };
+    }
+
+    /**
+     * Elimina un profesor del sistema (de users.json).
+     *
+     * Las tareas y notas asociadas permanecen intactas (RN-10):
+     * sus campos profesorId quedan apuntando a un usuario inexistente.
+     * No se hace eliminación en cascada.
+     *
+     * @param id ID del profesor a eliminar
+     */
+    public void delete(String id) {
+        Professor profesor = repo.findById(id)
+                .orElseThrow(() -> new AppException("Profesor no encontrado."));
+
+        // Eliminar el User subyacente de users.json
+        authRepository().deleteById(profesor.getId());
     }
 }

--- a/src/test/java/org/manageSchool/professor/ProfessorServiceTest.java
+++ b/src/test/java/org/manageSchool/professor/ProfessorServiceTest.java
@@ -1,5 +1,10 @@
 package org.manageSchool.professor;
 
+
+import org.manageSchool.task.TaskRepository;
+import org.manageSchool.task.Task;
+import org.manageSchool.grade.GradeRepository;
+import org.manageSchool.grade.Grade;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,14 +26,18 @@ public class ProfessorServiceTest {
     private ProfessorRepository repoMock;
     private AuthService authServiceMock;
     private ProfessorService service;
+    private TaskRepository taskRepoMock;
+    private GradeRepository gradeRepoMock;
 
     @BeforeEach
     void setUp() {
         repoMock = mock(ProfessorRepository.class);
         authServiceMock = mock(AuthService.class);
         authRepoMock = mock(AuthRepository.class);
+        taskRepoMock = mock(TaskRepository.class);
+        gradeRepoMock = mock(GradeRepository.class);
         when(repoMock.getAuthRepository()).thenReturn(authRepoMock);
-        service = new ProfessorService(repoMock, authServiceMock);
+        service = new ProfessorService(repoMock, authServiceMock, taskRepoMock, gradeRepoMock);
     }
 
     // ISSUE-027 / CP-PROF-001: crear profesor
@@ -239,5 +248,95 @@ public class ProfessorServiceTest {
         assertEquals("Pedro", actualizado.getNombre());
         assertEquals("pedro@colegio.edu.co", actualizado.getCorreo());
         verify(authRepoMock, times(1)).update(user);
+    }
+
+    // ===== ISSUE-030 / CP-PROF-004: Eliminar profesor =====
+
+    @Test
+    @DisplayName("CP-PROF-004: getDeletionInfo retorna conteo de tareas y notas")
+    void getDeletionInfo_retornaConteoCorrectoDeTareasYNotas() {
+        User user = User.crear("Laura", "laura@colegio.edu.co", "h", Professor.ROL);
+        when(repoMock.findById(user.getId()))
+                .thenReturn(java.util.Optional.of(new Professor(user)));
+
+        Task t1 = Task.create("Tarea 1", "desc", null, "m1", user.getId());
+        Task t2 = Task.create("Tarea 2", "desc", null, "m1", user.getId());
+        when(taskRepoMock.findByProfessorId(user.getId())).thenReturn(List.of(t1, t2));
+
+        Grade g1 = new Grade("g1", "est1", t1.getId(), "m1", 4.0, "2026-04-01", user.getId());
+        Grade g2 = new Grade("g2", "est2", t1.getId(), "m1", 3.5, "2026-04-01", user.getId());
+        Grade g3 = new Grade("g3", "est1", t2.getId(), "m1", 5.0, "2026-04-01", user.getId());
+        when(gradeRepoMock.findByTaskId(t1.getId())).thenReturn(List.of(g1, g2));
+        when(gradeRepoMock.findByTaskId(t2.getId())).thenReturn(List.of(g3));
+
+        int[] info = service.getDeletionInfo(user.getId());
+
+        assertEquals(2, info[0], "Debe reportar 2 tareas");
+        assertEquals(3, info[1], "Debe reportar 3 notas");
+    }
+
+    @Test
+    @DisplayName("CP-PROF-004: getDeletionInfo retorna [0,0] si no tiene tareas")
+    void getDeletionInfo_retornaCerosSiNoHayTareas() {
+        User user = User.crear("Pedro", "pedro@colegio.edu.co", "h", Professor.ROL);
+        when(repoMock.findById(user.getId()))
+                .thenReturn(java.util.Optional.of(new Professor(user)));
+        when(taskRepoMock.findByProfessorId(user.getId())).thenReturn(List.of());
+
+        int[] info = service.getDeletionInfo(user.getId());
+
+        assertEquals(0, info[0]);
+        assertEquals(0, info[1]);
+    }
+
+    @Test
+    @DisplayName("CP-PROF-004: delete elimina al profesor de users.json")
+    void delete_eliminaProfesorDelSistema() {
+        User user = User.crear("Laura", "laura@colegio.edu.co", "h", Professor.ROL);
+        when(repoMock.findById(user.getId()))
+                .thenReturn(java.util.Optional.of(new Professor(user)));
+
+        service.delete(user.getId());
+
+        verify(authRepoMock, times(1)).deleteById(user.getId());
+    }
+
+    @Test
+    @DisplayName("CP-PROF-004: delete lanza error si el profesor no existe")
+    void delete_lanzaErrorSiProfesorNoExiste() {
+        when(repoMock.findById("no-existe")).thenReturn(java.util.Optional.empty());
+
+        AppException ex = assertThrows(AppException.class,
+                () -> service.delete("no-existe"));
+
+        assertEquals("Profesor no encontrado.", ex.getMessage());
+    }
+
+    // ===== ISSUE-030 / CP-PROF-005: Tareas y notas huérfanas =====
+
+    @Test
+    @DisplayName("CP-PROF-005: delete NO elimina tareas del profesor (quedan huérfanas)")
+    void delete_noEliminaTareasDelProfesor() {
+        User user = User.crear("Laura", "laura@colegio.edu.co", "h", Professor.ROL);
+        when(repoMock.findById(user.getId()))
+                .thenReturn(java.util.Optional.of(new Professor(user)));
+
+        service.delete(user.getId());
+
+        // Verificar que NUNCA se llamó a eliminar tareas
+        verify(taskRepoMock, never()).deleteById(anyString());
+    }
+
+    @Test
+    @DisplayName("CP-PROF-005: delete NO elimina notas asociadas a tareas del profesor")
+    void delete_noEliminaNotasDelProfesor() {
+        User user = User.crear("Laura", "laura@colegio.edu.co", "h", Professor.ROL);
+        when(repoMock.findById(user.getId()))
+                .thenReturn(java.util.Optional.of(new Professor(user)));
+
+        service.delete(user.getId());
+
+        // Verificar que NUNCA se llamó a eliminar notas
+        verify(gradeRepoMock, never()).deleteById(anyString());
     }
 }


### PR DESCRIPTION
## Issue
Closes #15 — ISSUE-030 — HU-PROF-04: Admin elimina profesor

## Descripción
Implementa la eliminación de profesores desde el menú del administrador.
Antes de eliminar, el sistema informa cuántas tareas y notas quedarán
huérfanas y solicita confirmación explícita. Las tareas y notas permanecen
intactas (RN-10: sin eliminación en cascada).

## Cambios
- `ProfessorService`:
  - Constructor ampliado a 4 parámetros (+ TaskRepository, GradeRepository),
    constructor retrocompatible de 2 parámetros conservado
  - `getDeletionInfo(id)`: cuenta tareas y notas asociadas
  - `delete(id)`: elimina el User de users.json
- `ProfessorController`:
  - Nueva opción 4 "Eliminar profesor" (Volver pasa a opción 5)
  - Muestra aviso con conteo si hay tareas, solicita confirmación "SI"
- `ProfessorServiceTest`: 6 tests nuevos cubriendo CP-PROF-004 y CP-PROF-005

## Criterios de aceptación cubiertos
- [x] Si tiene tareas, muestra aviso con conteo y pide confirmación
- [x] Si no tiene tareas, pide confirmación directa
- [x] Al confirmar, el profesor desaparece de la lista
- [x] Tareas permanecen con profesorId huérfano (RN-10)
- [x] Notas asociadas se conservan intactas
- [x] Promedios y ranking no afectados (no se tocan grades ni ranking)
- [x] Muestra mensaje de éxito tras la eliminación

## Cómo probar
1. `mvn test` → +6 tests en verde
2. `mvn exec:java` → admin → menú 2 → opción 4
   - Crear un profesor, crear tareas con ese profesor, luego eliminar → aviso
   - Crear un profesor sin tareas, eliminar → confirmación directa
   - Cancelar eliminación → profesor sigue en la lista